### PR TITLE
bump to v29.0.0-alpha.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,15 @@ name = "autd3-emulator"
 description = "autd3 emulator for calculating sound field, emulation of firmware, etc"
 readme = "README.md"
 keywords = ["autd"]
-version = "28.0.0"
+version = "29.0.0-alpha.0"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/shinolab/autd3-emulator"
 
 [dependencies]
-autd3 = "28.0.0"
-autd3-firmware-emulator = "28.0.0"
+autd3 = "29.0.0-alpha.0"
+autd3-firmware-emulator = "29.0.0-alpha.0"
 derive_more = { version = "1.0.0", features = ["deref"] }
 polars = { version = "0.43.1", features = ["dtype-u8"], default-features = false }
 indicatif = "0.17.8"

--- a/examples/modulation.rs
+++ b/examples/modulation.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::Result;
 
 use autd3::prelude::*;
-use autd3_emulator::{Emulator, Range, RecordOption};
+use autd3_emulator::{Emulator, Range, RecordOption, RecorderControllerExt};
 
 use polars::prelude::AnyValue;
 use textplots::{Chart, Plot, Shape};

--- a/examples/modulation.rs
+++ b/examples/modulation.rs
@@ -25,14 +25,14 @@ async fn main() -> Result<()> {
             .await?;
 
         let df = record.drive();
-        let t = df["time[s]"].f32()?;
+        let t = df["time[ns]"].u64()?;
         let pulse_width = df["pulsewidth_0_0"].u8()?; // pulsewidth_<device idx>_<transducer idx>
         println!("pulse width under 200Hz sine modulation with silencer");
         Chart::new(180, 40, 5.0, 10.0)
             .lineplot(&Shape::Lines(
                 &t.into_no_null_iter()
                     .zip(pulse_width.into_no_null_iter())
-                    .map(|(t, v)| (t * 1000., v as f32))
+                    .map(|(t, v)| (t as f32 / 1000_000., v as f32))
                     .collect::<Vec<_>>(),
             ))
             .display();
@@ -51,14 +51,14 @@ async fn main() -> Result<()> {
             .await?;
 
         let df = record.drive();
-        let t = df["time[s]"].f32()?;
+        let t = df["time[ns]"].u64()?;
         let pulse_width = df["pulsewidth_0_0"].u8()?; // pulsewidth_<device idx>_<transducer idx>
         println!("pulse width under 200Hz sine modulation without silencer");
         Chart::new(180, 40, 5.0, 10.0)
             .lineplot(&Shape::Lines(
                 &t.into_no_null_iter()
                     .zip(pulse_width.into_no_null_iter())
-                    .map(|(t, v)| (t * 1000., v as f32))
+                    .map(|(t, v)| (t as f32 / 1000_000., v as f32))
                     .collect::<Vec<_>>(),
             ))
             .display();
@@ -96,11 +96,13 @@ async fn main() -> Result<()> {
 
         let df = sound_field.next(Duration::from_millis(20)).await?;
 
-        let t = df
-            .get_column_names()
-            .into_iter()
-            .skip(3)
-            .map(|n| n.as_str().replace("p[Pa]@", "").parse::<f32>().unwrap());
+        let t = df.get_column_names().into_iter().skip(3).map(|n| {
+            n.as_str()
+                .replace("p[Pa]@", "")
+                .replace("[ns]", "")
+                .parse::<u64>()
+                .unwrap()
+        });
         let p = df
             .get_row(0)?
             .0
@@ -113,7 +115,9 @@ async fn main() -> Result<()> {
         println!("sound pressure at focus under 200Hz sin modulation with silencer");
         Chart::new(180, 40, 0.0, 20.0)
             .lineplot(&Shape::Lines(
-                &t.zip(p).map(|(t, p)| (t * 1000., p)).collect::<Vec<_>>(),
+                &t.zip(p)
+                    .map(|(t, p)| (t as f32 / 1000_000., p))
+                    .collect::<Vec<_>>(),
             ))
             .display();
     }

--- a/examples/output_ultrasound.rs
+++ b/examples/output_ultrasound.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::Result;
 
 use autd3::prelude::*;
-use autd3_emulator::Emulator;
+use autd3_emulator::{Emulator, RecorderControllerExt};
 
 use textplots::{Chart, Plot, Shape};
 

--- a/examples/output_ultrasound.rs
+++ b/examples/output_ultrasound.rs
@@ -27,14 +27,15 @@ async fn main() -> Result<()> {
             .await?;
 
         let df = record.output_voltage();
-        let t = df["time[s]"].f32()?;
+        let t = df["time[25us/256]"].u64()?;
+        dbg!(&t);
         let v = df["voltage_0_0[V]"].f32()?; // voltage_<device idx>_<transducer idx>
         println!("output voltage");
         Chart::new(300, 40, 0.0, 1.0)
             .lineplot(&Shape::Lines(
                 &t.into_no_null_iter()
                     .zip(v.into_no_null_iter())
-                    .map(|(t, v)| (t * 1000., v))
+                    .map(|(t, v)| (t as f32 * 0.025 / 256., v))
                     .collect::<Vec<_>>(),
             ))
             .display();
@@ -56,14 +57,14 @@ async fn main() -> Result<()> {
             .await?;
 
         let df = record.output_ultrasound();
-        let t = df["time[s]"].f32()?;
+        let t = df["time[25us/256]"].u64()?;
         let v = df["p_0_0[a.u.]"].f32()?;
         println!("output ultrasound");
         Chart::new(300, 40, 0.0, 1.0)
             .lineplot(&Shape::Lines(
                 &t.into_no_null_iter()
                     .zip(v.into_no_null_iter())
-                    .map(|(t, v)| (t * 1000., v))
+                    .map(|(t, v)| (t as f32 * 0.025 / 256., v))
                     .collect::<Vec<_>>(),
             ))
             .display();

--- a/examples/plot_field.py
+++ b/examples/plot_field.py
@@ -11,7 +11,10 @@ from scipy.interpolate import griddata
 
 def plot_focus():
     df = pl.read_csv(Path(__file__).parent.parent / "sound_field_around_focus.csv")
-    times = [float(c.replace("p[Pa]@", "")) * 1000 for c in df.columns[3:]]
+    times = [
+        float(c.replace("p[Pa]@", "").replace("[ns]", "")) / 1000_000
+        for c in df.columns[3:]
+    ]
     p = df.get_columns()[3:]
     times = times[440:]
     p = p[440:]
@@ -64,8 +67,10 @@ def plot_focus():
 
 def plot_stm():
     df = pl.read_csv(Path(__file__).parent.parent / "sound_field_stm.csv")
-    print(df)
-    times = [float(c.replace("p[Pa]@", "")) * 1000 for c in df.columns[3:]]
+    times = [
+        float(c.replace("p[Pa]@", "").replace("[ns]", "")) / 1000_000
+        for c in df.columns[3:]
+    ]
     p = df.get_columns()[3:]
     times = times[700:]
     p = p[700:]

--- a/examples/sound_field.rs
+++ b/examples/sound_field.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::Result;
 
 use autd3::prelude::*;
-use autd3_emulator::{Emulator, Range, RecordOption};
+use autd3_emulator::{Emulator, Range, RecordOption, RecorderControllerExt};
 use polars::{io::SerWriter, prelude::CsvWriter};
 
 #[tokio::main]

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -32,7 +32,7 @@ impl Record {
     }
 
     #[cfg(feature = "inplace")]
-    pub fn drive_time_inplace(&self, time: &mut [f32]) {
+    pub fn drive_time_inplace(&self, time: &mut [u64]) {
         TransducerRecord::time_inplace(0, self.drive_time_len(), time)
     }
 
@@ -58,7 +58,7 @@ impl Record {
 
     pub fn drive(&self) -> DataFrame {
         let mut df =
-            df!("time[s]" => &TransducerRecord::time(0, self.records[0].records[0].pulse_width.len()))
+            df!("time[ns]" => &TransducerRecord::time(0, self.records[0].records[0].pulse_width.len()))
                 .unwrap();
         let series = self
             .records

--- a/src/record/output_ultrasound.rs
+++ b/src/record/output_ultrasound.rs
@@ -30,7 +30,7 @@ impl Record {
             })
             .collect::<Vec<_>>();
 
-        let mut df = df!("time[s]" => &time).unwrap();
+        let mut df = df!("time[25us/256]" => &time).unwrap();
         df.hstack_mut(&series).unwrap();
         df
     }

--- a/src/record/output_voltage.rs
+++ b/src/record/output_voltage.rs
@@ -10,7 +10,7 @@ impl Record {
     }
 
     #[cfg(feature = "inplace")]
-    pub fn output_voltage_time_inplace(&self, time: &mut [f32]) {
+    pub fn output_voltage_time_inplace(&self, time: &mut [u64]) {
         let n = self.records[0].records[0].pulse_width.len();
         self.records[0].records[0].output_times_inplace(0, n, time);
     }
@@ -36,7 +36,7 @@ impl Record {
             })
             .collect::<Vec<_>>();
 
-        let mut df = df!("time[s]" => &t).unwrap();
+        let mut df = df!("time[25us/256]" => &t).unwrap();
         df.hstack_mut(&series).unwrap();
         df
     }

--- a/src/record/sound_field/mod.rs
+++ b/src/record/sound_field/mod.rs
@@ -89,7 +89,7 @@ pub struct SoundField<'a> {
 impl<'a> SoundField<'a> {
     pub async fn next(&mut self, duration: Duration) -> Result<DataFrame, EmulatorError> {
         let n = self.next_time_len(duration);
-        let mut time = vec![0.0; n];
+        let mut time = vec![0; n];
         let mut v = vec![vec![0.0; self.next_points_len()]; n];
         self.next_inplace(
             duration,
@@ -102,7 +102,7 @@ impl<'a> SoundField<'a> {
         let columns = time
             .iter()
             .zip(v.iter())
-            .map(|(t, v)| Series::new(format!("p[Pa]@{}", t).into(), v))
+            .map(|(t, v)| Series::new(format!("p[Pa]@{}[ns]", t).into(), v))
             .collect::<Vec<_>>();
 
         let mut df = df!(
@@ -153,7 +153,7 @@ impl<'a> SoundField<'a> {
         &mut self,
         duration: Duration,
         skip: bool,
-        time: &mut [f32],
+        time: &mut [u64],
         mut v: impl Iterator<Item = *mut f32>,
     ) -> Result<(), EmulatorError> {
         if duration.as_nanos() % ULTRASOUND_PERIOD.as_nanos() != 0 {
@@ -198,11 +198,11 @@ impl<'a> SoundField<'a> {
             if !skip {
                 let offset = (self.cursor - self.cache_size) * ULTRASOUND_PERIOD_COUNT as isize;
                 for i in 0..num_frames {
-                    let start_time = ((cur_frame + i) as u32 * ULTRASOUND_PERIOD).as_secs_f32();
+                    let start_time = (cur_frame + i) as u32 * ULTRASOUND_PERIOD;
                     let r = self
                         .compute_device
                         .compute(
-                            start_time,
+                            start_time.as_secs_f32(),
                             time_step,
                             self.num_points_in_frame,
                             sound_speed,
@@ -211,7 +211,7 @@ impl<'a> SoundField<'a> {
                         )
                         .await?; // GRCOV_EXCL_LINE
                     (0..r.len()).for_each(|i| {
-                        time[idx] = start_time + (i as u32 * time_step).as_secs_f32();
+                        time[idx] = (start_time + (i as u32 * time_step)).as_nanos() as u64;
                         unsafe {
                             std::ptr::copy_nonoverlapping(
                                 r[i].as_ptr(),

--- a/src/record/transducer/mod.rs
+++ b/src/record/transducer/mod.rs
@@ -14,15 +14,15 @@ pub(crate) struct TransducerRecord {
 }
 
 impl TransducerRecord {
-    pub(crate) fn time_inplace(start: usize, n: usize, time: &mut [f32]) {
+    pub(crate) fn time_inplace(start: usize, n: usize, time: &mut [u64]) {
         (start..)
             .take(n)
             .zip(time.iter_mut())
-            .for_each(|(i, dst)| *dst = (i as u32 * ULTRASOUND_PERIOD).as_secs_f32());
+            .for_each(|(i, dst)| *dst = (i as u32 * ULTRASOUND_PERIOD).as_nanos() as u64);
     }
 
-    pub(crate) fn time(start: usize, n: usize) -> Vec<f32> {
-        let mut time = vec![0.; n];
+    pub(crate) fn time(start: usize, n: usize) -> Vec<u64> {
+        let mut time = vec![0; n];
         Self::time_inplace(start, n, &mut time);
         time
     }

--- a/src/record/transducer/output_voltage.rs
+++ b/src/record/transducer/output_voltage.rs
@@ -1,4 +1,4 @@
-use autd3::driver::defined::{ULTRASOUND_FREQ, ULTRASOUND_PERIOD, ULTRASOUND_PERIOD_COUNT};
+use autd3::driver::defined::{ULTRASOUND_FREQ, ULTRASOUND_PERIOD_COUNT};
 
 use super::TransducerRecord;
 
@@ -6,19 +6,18 @@ impl TransducerRecord {
     pub(crate) const TS: f32 = 1. / (ULTRASOUND_FREQ.hz() as f32 * ULTRASOUND_PERIOD_COUNT as f32);
     pub(crate) const V: f32 = 12.0;
 
-    pub(crate) fn output_times_inplace(&self, start: usize, n: usize, time: &mut [f32]) {
+    pub(crate) fn output_times_inplace(&self, start: usize, n: usize, time: &mut [u64]) {
         (start..)
             .take(n)
-            .map(|i| i as u32 * ULTRASOUND_PERIOD)
-            .flat_map(|t| {
-                (0..ULTRASOUND_PERIOD_COUNT).map(move |i| t.as_secs_f32() + i as f32 * Self::TS)
+            .flat_map(|i| {
+                (0..ULTRASOUND_PERIOD_COUNT).map(move |j| i * ULTRASOUND_PERIOD_COUNT + j)
             })
             .zip(time.iter_mut())
-            .for_each(|(src, dst)| *dst = src);
+            .for_each(|(src, dst)| *dst = src as _);
     }
 
-    pub(crate) fn output_times(&self, start: usize, n: usize) -> Vec<f32> {
-        let mut time = vec![0.; n * ULTRASOUND_PERIOD_COUNT];
+    pub(crate) fn output_times(&self, start: usize, n: usize) -> Vec<u64> {
+        let mut time = vec![0; n * ULTRASOUND_PERIOD_COUNT];
         self.output_times_inplace(start, n, &mut time);
         time
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,5 @@
 use autd3::{derive::Datagram, driver::firmware::fpga::FPGA_MAIN_CLK_FREQ, gain, prelude::*};
-use autd3_emulator::{Emulator, Range, RecordOption};
+use autd3_emulator::{Emulator, Range, RecordOption, RecorderControllerExt};
 
 use polars::prelude::{df, NamedFrom, Series};
 use std::time::Duration;


### PR DESCRIPTION
- **bump to v29.0.0-alpha.0**
- **use `u64` for time instead of `f32`**
